### PR TITLE
Replace an unwrap with ok_or in parser

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -273,7 +273,10 @@ where
     if !options.lenient && (!incomplete_child_lists.is_empty() || collection.len() != 1) {
         return Err(SgfParseError::UnexpectedEndOfData);
     }
-    let mut root_node = collection.into_iter().next().unwrap();
+    let mut root_node = collection
+        .into_iter()
+        .next()
+        .ok_or(SgfParseError::UnexpectedEndOfData)?;
     root_node.is_root = true;
     Ok(root_node.into())
 }


### PR DESCRIPTION
Ran into a panic with some file from #25 . Not sure which file it was actually but this change fixed it. 

I suspect that functions that return a `Result` should never `unwrap` anything but always use `ok_or` but I haven't dug into replacing the other unwraps.